### PR TITLE
Updated contribute-mozilla.html

### DIFF
--- a/contribute-mozilla.html
+++ b/contribute-mozilla.html
@@ -48,7 +48,7 @@
       </section>
       <section>
         <h2>¿Cómo empezar a contribuir a Mozilla?</h2>
-        <a class='fragment' href='https://contribute.mozilla.org'>contribute.mozilla.org</a>
+        <a class='fragment' href='https://activate.mozilla.community/contribute'>contribute.mozilla.org</a>
       </section>
       <section>
         <h2>Ayuda en una campaña</h2>


### PR DESCRIPTION
with the new site for contribution https://activate.mozilla.community/ which is going to revert back to the link being changed contribute.mozilla.org starting in April 2020.